### PR TITLE
Add 1999 platform sample pages

### DIFF
--- a/public/1999/admin.html
+++ b/public/1999/admin.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>管理端</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav>
+    <ul>
+      <li><a href="index.html">首頁</a></li>
+      <li><a href="schedule.html">話務班表查詢</a></li>
+      <li><a href="news.html">最新公告</a></li>
+      <li><a href="links.html">常用連結</a></li>
+      <li><a href="resources.html">學習資源</a></li>
+      <li><a href="forms.html">問卷與表單</a></li>
+      <li><a href="wall.html">同仁交流牆</a></li>
+      <li><a href="reports.html">報表整合平台</a></li>
+      <li><a href="admin.html">管理端</a></li>
+    </ul>
+  </nav>
+  <main>
+    <h1>管理端</h1>
+    <p>此頁面提供管理相關功能。</p>
+  </main>
+</body>
+</html>

--- a/public/1999/forms.html
+++ b/public/1999/forms.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>問卷與表單</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav>
+    <ul>
+      <li><a href="index.html">首頁</a></li>
+      <li><a href="schedule.html">話務班表查詢</a></li>
+      <li><a href="news.html">最新公告</a></li>
+      <li><a href="links.html">常用連結</a></li>
+      <li><a href="resources.html">學習資源</a></li>
+      <li><a href="forms.html">問卷與表單</a></li>
+      <li><a href="wall.html">同仁交流牆</a></li>
+      <li><a href="reports.html">報表整合平台</a></li>
+      <li><a href="admin.html">管理端</a></li>
+    </ul>
+  </nav>
+  <main>
+    <h1>問卷與表單</h1>
+    <p>在此頁面提供各式問卷與表單。</p>
+  </main>
+</body>
+</html>

--- a/public/1999/index.html
+++ b/public/1999/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>1999 平台首頁</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav>
+    <ul>
+      <li><a href="index.html">首頁</a></li>
+      <li><a href="schedule.html">話務班表查詢</a></li>
+      <li><a href="news.html">最新公告</a></li>
+      <li><a href="links.html">常用連結</a></li>
+      <li><a href="resources.html">學習資源</a></li>
+      <li><a href="forms.html">問卷與表單</a></li>
+      <li><a href="wall.html">同仁交流牆</a></li>
+      <li><a href="reports.html">報表整合平台</a></li>
+      <li><a href="admin.html">管理端</a></li>
+    </ul>
+  </nav>
+  <main>
+    <h1>歡迎來到 1999 平台</h1>
+    <p>請從上方選單選擇功能。</p>
+  </main>
+</body>
+</html>

--- a/public/1999/links.html
+++ b/public/1999/links.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>常用連結</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav>
+    <ul>
+      <li><a href="index.html">首頁</a></li>
+      <li><a href="schedule.html">話務班表查詢</a></li>
+      <li><a href="news.html">最新公告</a></li>
+      <li><a href="links.html">常用連結</a></li>
+      <li><a href="resources.html">學習資源</a></li>
+      <li><a href="forms.html">問卷與表單</a></li>
+      <li><a href="wall.html">同仁交流牆</a></li>
+      <li><a href="reports.html">報表整合平台</a></li>
+      <li><a href="admin.html">管理端</a></li>
+    </ul>
+  </nav>
+  <main>
+    <h1>常用連結</h1>
+    <p>在此頁面放置常用連結列表。</p>
+  </main>
+</body>
+</html>

--- a/public/1999/news.html
+++ b/public/1999/news.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>最新公告</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav>
+    <ul>
+      <li><a href="index.html">首頁</a></li>
+      <li><a href="schedule.html">話務班表查詢</a></li>
+      <li><a href="news.html">最新公告</a></li>
+      <li><a href="links.html">常用連結</a></li>
+      <li><a href="resources.html">學習資源</a></li>
+      <li><a href="forms.html">問卷與表單</a></li>
+      <li><a href="wall.html">同仁交流牆</a></li>
+      <li><a href="reports.html">報表整合平台</a></li>
+      <li><a href="admin.html">管理端</a></li>
+    </ul>
+  </nav>
+  <main>
+    <h1>最新公告</h1>
+    <p>在此頁面發佈最新公告內容。</p>
+  </main>
+</body>
+</html>

--- a/public/1999/reports.html
+++ b/public/1999/reports.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>報表整合平台</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav>
+    <ul>
+      <li><a href="index.html">首頁</a></li>
+      <li><a href="schedule.html">話務班表查詢</a></li>
+      <li><a href="news.html">最新公告</a></li>
+      <li><a href="links.html">常用連結</a></li>
+      <li><a href="resources.html">學習資源</a></li>
+      <li><a href="forms.html">問卷與表單</a></li>
+      <li><a href="wall.html">同仁交流牆</a></li>
+      <li><a href="reports.html">報表整合平台</a></li>
+      <li><a href="admin.html">管理端</a></li>
+    </ul>
+  </nav>
+  <main>
+    <h1>報表整合平台</h1>
+    <p>在此頁面查看及匯整各項報表。</p>
+  </main>
+</body>
+</html>

--- a/public/1999/resources.html
+++ b/public/1999/resources.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>學習資源</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav>
+    <ul>
+      <li><a href="index.html">首頁</a></li>
+      <li><a href="schedule.html">話務班表查詢</a></li>
+      <li><a href="news.html">最新公告</a></li>
+      <li><a href="links.html">常用連結</a></li>
+      <li><a href="resources.html">學習資源</a></li>
+      <li><a href="forms.html">問卷與表單</a></li>
+      <li><a href="wall.html">同仁交流牆</a></li>
+      <li><a href="reports.html">報表整合平台</a></li>
+      <li><a href="admin.html">管理端</a></li>
+    </ul>
+  </nav>
+  <main>
+    <h1>學習資源</h1>
+    <p>在此頁面放置學習資源與教材。</p>
+  </main>
+</body>
+</html>

--- a/public/1999/schedule.html
+++ b/public/1999/schedule.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>話務班表查詢</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav>
+    <ul>
+      <li><a href="index.html">首頁</a></li>
+      <li><a href="schedule.html">話務班表查詢</a></li>
+      <li><a href="news.html">最新公告</a></li>
+      <li><a href="links.html">常用連結</a></li>
+      <li><a href="resources.html">學習資源</a></li>
+      <li><a href="forms.html">問卷與表單</a></li>
+      <li><a href="wall.html">同仁交流牆</a></li>
+      <li><a href="reports.html">報表整合平台</a></li>
+      <li><a href="admin.html">管理端</a></li>
+    </ul>
+  </nav>
+  <main>
+    <h1>話務班表查詢</h1>
+    <p>此頁面可提供話務班表查詢功能。</p>
+  </main>
+</body>
+</html>

--- a/public/1999/styles.css
+++ b/public/1999/styles.css
@@ -1,0 +1,29 @@
+body{
+  font-family: Arial, sans-serif;
+  margin:0;
+  padding:0;
+}
+nav{
+  background:#333;
+}
+nav ul{
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:flex;
+}
+nav li{
+  margin:0;
+}
+nav a{
+  display:block;
+  padding:10px 15px;
+  color:#fff;
+  text-decoration:none;
+}
+nav a:hover{
+  background:#555;
+}
+main{
+  padding:20px;
+}

--- a/public/1999/wall.html
+++ b/public/1999/wall.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>同仁交流牆</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav>
+    <ul>
+      <li><a href="index.html">首頁</a></li>
+      <li><a href="schedule.html">話務班表查詢</a></li>
+      <li><a href="news.html">最新公告</a></li>
+      <li><a href="links.html">常用連結</a></li>
+      <li><a href="resources.html">學習資源</a></li>
+      <li><a href="forms.html">問卷與表單</a></li>
+      <li><a href="wall.html">同仁交流牆</a></li>
+      <li><a href="reports.html">報表整合平台</a></li>
+      <li><a href="admin.html">管理端</a></li>
+    </ul>
+  </nav>
+  <main>
+    <h1>同仁交流牆</h1>
+    <p>在此頁面提供同仁交流與留言功能。</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add example multi-page site under `public/1999`
- include navigation and placeholder content for requested sections

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684060d63510832db740995ed6e5cccf