### PR TITLE
Add Virtual Desk electron-react skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 node_modules
 public/styles/*
+
+virtual-desk/node_modules
+virtual-desk/renderer/node_modules
+virtual-desk/renderer/build
+package-lock.json

--- a/virtual-desk/db/database.js
+++ b/virtual-desk/db/database.js
@@ -1,0 +1,91 @@
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const dbPath = path.join(__dirname, 'zones.db');
+let db;
+
+function initializeDatabase() {
+  db = new sqlite3.Database(dbPath);
+  db.serialize(() => {
+    db.run(`CREATE TABLE IF NOT EXISTS zones (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      folderPath TEXT NOT NULL UNIQUE,
+      color TEXT DEFAULT '#3B82F6',
+      zone_style TEXT DEFAULT '{}',
+      notes TEXT DEFAULT '',
+      description TEXT DEFAULT '',
+      is_pinned INTEGER DEFAULT 0,
+      pin_order INTEGER DEFAULT 0,
+      createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )`);
+  });
+}
+
+function createZone({ name, folderPath, color, zone_style, description = '', notes = '' }) {
+  return new Promise((resolve, reject) => {
+    const stmt = db.prepare(`INSERT INTO zones (name, folderPath, color, zone_style, description, notes) VALUES (?, ?, ?, ?, ?, ?)`);
+    stmt.run(name, folderPath, color, JSON.stringify(zone_style || {}), description, notes, function (err) {
+      if (err) return reject(err);
+      resolve({ success: true, id: this.lastID });
+    });
+    stmt.finalize();
+  });
+}
+
+function loadZones() {
+  return new Promise((resolve, reject) => {
+    db.all(`SELECT * FROM zones ORDER BY is_pinned DESC, pin_order ASC`, [], (err, rows) => {
+      if (err) return reject(err);
+      resolve({ success: true, zones: rows });
+    });
+  });
+}
+
+function updateZone(id, updates) {
+  return new Promise((resolve, reject) => {
+    const fields = Object.keys(updates).map(key => `${key} = ?`).join(', ');
+    const values = Object.values(updates);
+    values.push(id);
+    const stmt = db.prepare(`UPDATE zones SET ${fields}, updatedAt=CURRENT_TIMESTAMP WHERE id = ?`);
+    stmt.run(values, function (err) {
+      if (err) return reject(err);
+      resolve({ success: this.changes > 0 });
+    });
+    stmt.finalize();
+  });
+}
+
+function deleteZone(id) {
+  return new Promise((resolve, reject) => {
+    db.run(`DELETE FROM zones WHERE id = ?`, id, function (err) {
+      if (err) return reject(err);
+      resolve({ success: this.changes > 0 });
+    });
+  });
+}
+
+function updatePinOrder(pinUpdates) {
+  return new Promise((resolve, reject) => {
+    const stmt = db.prepare(`UPDATE zones SET pin_order = ?, is_pinned = 1 WHERE id = ?`);
+    db.serialize(() => {
+      pinUpdates.forEach(({ id, pin_order }) => {
+        stmt.run(pin_order, id);
+      });
+      stmt.finalize((err) => {
+        if (err) return reject(err);
+        resolve({ success: true });
+      });
+    });
+  });
+}
+
+module.exports = {
+  initializeDatabase,
+  createZone,
+  loadZones,
+  updateZone,
+  deleteZone,
+  updatePinOrder
+};

--- a/virtual-desk/ipc-handlers.js
+++ b/virtual-desk/ipc-handlers.js
@@ -1,0 +1,59 @@
+const { ipcMain, Menu } = require('electron');
+const fs = require('fs');
+const path = require('path');
+const {
+  initializeDatabase,
+  createZone,
+  loadZones,
+  updateZone,
+  deleteZone,
+  updatePinOrder
+} = require('./db/database');
+
+initializeDatabase();
+
+function setupIpcHandlers(mainWindow) {
+  ipcMain.handle('list-files', async (event, folderPath) => {
+    try {
+      const files = await fs.promises.readdir(folderPath);
+      const fileDetails = await Promise.all(
+        files.map(async (file) => {
+          const filePath = path.join(folderPath, file);
+          const stats = await fs.promises.stat(filePath);
+          return {
+            name: file,
+            path: filePath,
+            isDirectory: stats.isDirectory(),
+            size: stats.size,
+            modified: stats.mtime
+          };
+        })
+      );
+      return { success: true, files: fileDetails };
+    } catch (err) {
+      console.error('Error listing files:', err);
+      return { success: false, error: err.message };
+    }
+  });
+
+  ipcMain.handle('create-zone', (event, data) => createZone(data));
+  ipcMain.handle('load-zones', () => loadZones());
+  ipcMain.handle('update-zone', (event, id, updates) => updateZone(id, updates));
+  ipcMain.handle('delete-zone', (event, id) => deleteZone(id));
+  ipcMain.handle('update-pin-order', (event, updates) => updatePinOrder(updates));
+
+  ipcMain.on('show-file-menu', (event, filePath) => {
+    const template = [
+      {
+        label: 'Open',
+        click: () => {
+          require('electron').shell.openPath(filePath);
+        }
+      }
+    ];
+    const menu = Menu.buildFromTemplate(template);
+    menu.popup({ window: mainWindow });
+  });
+}
+
+module.exports = { setupIpcHandlers };

--- a/virtual-desk/main.js
+++ b/virtual-desk/main.js
@@ -1,0 +1,41 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+const isDev = process.env.NODE_ENV === 'development';
+const { setupIpcHandlers } = require('./ipc-handlers');
+
+function createWindow() {
+  const mainWindow = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+
+  const startUrl = isDev
+    ? 'http://localhost:3000'
+    : `file://${path.join(__dirname, './renderer/build/index.html')}`;
+  mainWindow.loadURL(startUrl);
+
+  setupIpcHandlers(mainWindow);
+
+  if (isDev) {
+    mainWindow.webContents.openDevTools();
+  }
+}
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('activate', () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow();
+  }
+});

--- a/virtual-desk/package.json
+++ b/virtual-desk/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "virtual-desk",
+  "version": "0.1.0",
+  "main": "main.js",
+  "scripts": {
+    "dev": "concurrently \"npm:start --prefix renderer\" \"wait-on http://localhost:3000 && electron .\"",
+    "start": "electron .",
+    "build": "npm run build --prefix renderer && electron-builder",
+    "package": "electron-builder"
+  },
+  "dependencies": {
+    "electron": "^26.2.0",
+    "sqlite3": "^5.1.6",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "concurrently": "^8.0.1",
+    "wait-on": "^7.0.1",
+    "electron-builder": "^24.6.0"
+  }
+}

--- a/virtual-desk/preload.js
+++ b/virtual-desk/preload.js
@@ -1,0 +1,15 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  createZone: (data) => ipcRenderer.invoke('create-zone', data),
+  listFiles: (folderPath) => ipcRenderer.invoke('list-files', folderPath),
+  loadZones: () => ipcRenderer.invoke('load-zones'),
+  updateZone: (id, updates) => ipcRenderer.invoke('update-zone', id, updates),
+  deleteZone: (id) => ipcRenderer.invoke('delete-zone', id),
+  updatePinOrder: (updates) => ipcRenderer.invoke('update-pin-order', updates),
+  showFileMenu: (filePath) => ipcRenderer.send('show-file-menu', filePath),
+  onNotification: (callback) => {
+    ipcRenderer.on('show-notification', callback);
+    return () => ipcRenderer.removeListener('show-notification', callback);
+  }
+});

--- a/virtual-desk/renderer/package.json
+++ b/virtual-desk/renderer/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "virtual-desk-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.3.3"
+  }
+}

--- a/virtual-desk/renderer/public/index.html
+++ b/virtual-desk/renderer/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Virtual Desk</title>
+    <link rel="stylesheet" href="/index.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.js"></script>
+  </body>
+</html>

--- a/virtual-desk/renderer/src/App.jsx
+++ b/virtual-desk/renderer/src/App.jsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+import ZoneCard from './components/ZoneCard.jsx';
+
+function App() {
+  const [zones, setZones] = useState([]);
+
+  useEffect(() => {
+    window.electronAPI.loadZones().then(result => {
+      if (result.success) setZones(result.zones);
+    });
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Virtual Desk</h1>
+      <div className="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+        {zones.map(zone => (
+          <ZoneCard key={zone.id} zone={zone} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/virtual-desk/renderer/src/components/FileItem.jsx
+++ b/virtual-desk/renderer/src/components/FileItem.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function FileItem() {
+  return <div>FileItem component</div>;
+}
+
+export default FileItem;

--- a/virtual-desk/renderer/src/components/NotesEditor.jsx
+++ b/virtual-desk/renderer/src/components/NotesEditor.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function NotesEditor() {
+  return <div>NotesEditor component</div>;
+}
+
+export default NotesEditor;

--- a/virtual-desk/renderer/src/components/PinnedZones.jsx
+++ b/virtual-desk/renderer/src/components/PinnedZones.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function PinnedZones() {
+  return <div>PinnedZones component</div>;
+}
+
+export default PinnedZones;

--- a/virtual-desk/renderer/src/components/SearchBar.jsx
+++ b/virtual-desk/renderer/src/components/SearchBar.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function SearchBar() {
+  return <div>SearchBar component</div>;
+}
+
+export default SearchBar;

--- a/virtual-desk/renderer/src/components/SearchResults.jsx
+++ b/virtual-desk/renderer/src/components/SearchResults.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function SearchResults() {
+  return <div>SearchResults component</div>;
+}
+
+export default SearchResults;

--- a/virtual-desk/renderer/src/components/StyleEditorModal.jsx
+++ b/virtual-desk/renderer/src/components/StyleEditorModal.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function StyleEditorModal() {
+  return <div>StyleEditorModal component</div>;
+}
+
+export default StyleEditorModal;

--- a/virtual-desk/renderer/src/components/ZoneCard.jsx
+++ b/virtual-desk/renderer/src/components/ZoneCard.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function ZoneCard({ zone }) {
+  return (
+    <div className="border rounded p-4" style={{ backgroundColor: zone.color }}>
+      <h2 className="font-semibold mb-2">{zone.name}</h2>
+      <p className="text-sm break-all">{zone.folderPath}</p>
+    </div>
+  );
+}
+
+export default ZoneCard;

--- a/virtual-desk/renderer/src/index.css
+++ b/virtual-desk/renderer/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: sans-serif;
+}

--- a/virtual-desk/renderer/src/index.js
+++ b/virtual-desk/renderer/src/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/virtual-desk/renderer/tailwind.config.js
+++ b/virtual-desk/renderer/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './public/index.html',
+    './src/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/virtual-desk/renderer/vite.config.js
+++ b/virtual-desk/renderer/vite.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  root: '.',
+  plugins: [react()],
+  build: {
+    outDir: 'build',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add Electron app skeleton with React frontend under `virtual-desk`
- provide SQLite persistence and IPC handlers
- setup React project with Vite and Tailwind
- update `.gitignore` for new build artifacts

## Testing
- `git status --short`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68729ea16ab0832dbd3c93ccef3e01a0)